### PR TITLE
Only show objects with images in curated article grids with an embark ID

### DIFF
--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -708,6 +708,10 @@ export default {
 
       if (component.embark_ID) {
         filterMust.push({ "term": { "Portfolios.Portfolio_ID" : `${component.embark_ID}` } });
+
+        if (this.variant === 'curated') {
+          filterMust.push({ "exists": {"field": "Images" }});
+        }
       }
 
       if (this.page == undefined && this.$refs.filter) {

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -706,6 +706,7 @@ export default {
         filterMust.push({ "exists": { "field" : "Images" } });
       }
 
+      // Set the collection filter but show only objects with images if it's a curated peek 
       if (component.embark_ID) {
         filterMust.push({ "term": { "Portfolios.Portfolio_ID" : `${component.embark_ID}` } });
 


### PR DESCRIPTION
@gregoryspragginsjr This issue was bubbling in some internal email discussions so here's a quick fix that should remove collection objects without images from article grids when the grid is serving as a peek for a collection. 

Looking at the code it appeared that this would only affect that one situation, but let me know if this will not work for whatever reason as I only have an initial familiarity with the grid component. 