### PR TITLE
Test removing smooth scroll plugin

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -112,7 +112,7 @@ export default {
       });
   },
   mounted() {
-    gsap.registerPlugin(ScrollTrigger);
+    // gsap.registerPlugin(ScrollTrigger);
 
     // setTimeout(() => {
     //   ScrollSmoother.create({

--- a/app.vue
+++ b/app.vue
@@ -112,14 +112,14 @@ export default {
       });
   },
   mounted() {
-    gsap.registerPlugin(ScrollTrigger, ScrollSmoother);
+    gsap.registerPlugin(ScrollTrigger);
 
-    setTimeout(() => {
-      ScrollSmoother.create({
-          smooth: 1.1,
-          effects: true,
-      });
-    }, 600);
+    // setTimeout(() => {
+    //   ScrollSmoother.create({
+    //       smooth: 1.1,
+    //       effects: true,
+    //   });
+    // }, 600);
   },
   methods: {
     formatTime(t) {


### PR DESCRIPTION
DO NOT MERGE! 

This PR removes GSAP's scrollsmoother which seems to be having issues with pages whose heights change dynamically after page load and / or lower-resource devices. Publishing as a PR to get a testable URL for users who were reporting issues.