### PR TITLE
Calculate and use `aspect-ratio` for WP-based media

### DIFF
--- a/components/global/Article.vue
+++ b/components/global/Article.vue
@@ -197,16 +197,29 @@ export default {
     },
     async getImage(i) {
       const component = this;
-      let imageObj;
-      let newImageObj;
 
-      await axios
-        .get(`${component.interface.endpoint}media/${i}`)
-        .then((output) => {
-          imageObj = output.data;
-          // console.log(imageObj);
+      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
+      const imageObj = image.data
+      const mediaDetails = image.data.media_details
+ 
+      let imageAspect
+      if (mediaDetails.height > 0 && mediaDetails.width > 0) {
+        imageAspect = mediaDetails.height / mediaDetails.width
+      }
 
-          newImageObj = {
+      const desktopWidth = 1200
+      const mobileWidth = 600
+
+      const desktop = { width: desktopWidth, 
+                        height: desktopWidth * imageAspect, 
+                        aspect_ratio: imageAspect,
+                        source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
+      const mobile = { width: mobileWidth, 
+                       height: mobileWidth * imageAspect, 
+                       aspect_ratio: imageAspect,
+                       source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
+
+      const newImageObj = {
             artist_name: imageObj.acf.artist_name,
             object_title: imageObj.acf.object_title,
             object_creation_date: imageObj.acf.object_creation_date,
@@ -216,20 +229,13 @@ export default {
             },
             media_details: {
               sizes: {
-                desktop: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
-                },
-                mobile: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp`,
-                },
+                desktop,
+                mobile,
               }
             }
-          };
+          }
 
-          // console.log(newImageObj);
-        });
-
-      return await newImageObj;
+      return newImageObj;
     },
     async updateImage() {
       if (this.post) {

--- a/components/global/Article.vue
+++ b/components/global/Article.vue
@@ -197,22 +197,16 @@ export default {
     },
     async getImage(i) {
       const component = this;
+      let imageObj;
+      let newImageObj;
 
-      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
-      const imageObj = image.data
+      await axios
+        .get(`${component.interface.endpoint}media/${i}`)
+        .then((output) => {
+          imageObj = output.data;
+          // console.log(imageObj);
 
-      let imageAspect = 3.0 / 4.0
-      if (image.height > 0 && image.width > 0) {
-        imgAspect = image.height / image.width
-      }
-
-      const desktopWidth = 1200
-      const mobileWidth = 600
-
-      const desktop = { width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
-      const mobile = { width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
-
-      const newImageObj = {
+          newImageObj = {
             artist_name: imageObj.acf.artist_name,
             object_title: imageObj.acf.object_title,
             object_creation_date: imageObj.acf.object_creation_date,
@@ -222,13 +216,20 @@ export default {
             },
             media_details: {
               sizes: {
-                desktop,
-                mobile,
+                desktop: {
+                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
+                },
+                mobile: {
+                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp`,
+                },
               }
             }
-          }
+          };
 
-      return newImageObj;
+          // console.log(newImageObj);
+        });
+
+      return await newImageObj;
     },
     async updateImage() {
       if (this.post) {

--- a/components/global/Article.vue
+++ b/components/global/Article.vue
@@ -197,16 +197,22 @@ export default {
     },
     async getImage(i) {
       const component = this;
-      let imageObj;
-      let newImageObj;
 
-      await axios
-        .get(`${component.interface.endpoint}media/${i}`)
-        .then((output) => {
-          imageObj = output.data;
-          // console.log(imageObj);
+      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
+      const imageObj = image.data
 
-          newImageObj = {
+      let imageAspect = 3.0 / 4.0
+      if (image.height > 0 && image.width > 0) {
+        imgAspect = image.height / image.width
+      }
+
+      const desktopWidth = 1200
+      const mobileWidth = 600
+
+      const desktop = { width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
+      const mobile = { width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
+
+      const newImageObj = {
             artist_name: imageObj.acf.artist_name,
             object_title: imageObj.acf.object_title,
             object_creation_date: imageObj.acf.object_creation_date,
@@ -216,20 +222,13 @@ export default {
             },
             media_details: {
               sizes: {
-                desktop: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
-                },
-                mobile: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp`,
-                },
+                desktop,
+                mobile,
               }
             }
-          };
+          }
 
-          // console.log(newImageObj);
-        });
-
-      return await newImageObj;
+      return newImageObj;
     },
     async updateImage() {
       if (this.post) {

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -1108,6 +1108,13 @@ export default {
           .then((output) => {
             imageObj = output.data;
 
+            const mediaDetails = output.data.media_details
+       
+            let imageAspect
+            if (mediaDetails.height > 0 && mediaDetails.width > 0) {
+              imageAspect = mediaDetails.height / mediaDetails.width
+            }
+
             // console.log(`${component.interface.endpoint}media/${i}`);
             // console.log(imageObj);
 
@@ -1124,9 +1131,11 @@ export default {
               media_details: {
                 sizes: {
                   desktop: {
+                    aspect_ratio: imageAspect,
                     source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=800,quality=75,format=webp`,
                   },
                   mobile: {
+                    aspect_ratio: imageAspect,
                     source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=400,quality=75,format=webp`,
                   },
                 }

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -659,35 +659,35 @@ export default {
     },
     async getImage(i) {
       const component = this;
-      let imageObj;
-      let newImageObj;
 
-      await axios
-        .get(`${component.interface.endpoint}media/${i}`)
-        .then((output) => {
-          imageObj = output.data;
+      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
+      const imageObj = image.data
 
-          // console.log(imageObj);
+      let imageAspect = 3.0 / 4.0
+      if (image.height > 0 && image.width > 0) {
+        imgAspect = image.height / image.width
+      }
 
-          newImageObj = {
+      const desktopWidth = 1200
+      const mobileWidth = 600
+
+      const desktop = { width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
+      const mobile = { width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
+
+      const newImageObj = {
             alt_text: imageObj.alt_text,
             caption: {
               rendered: imageObj.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
             },
             media_details: {
               sizes: {
-                desktop: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1800,quality=75,format=webp`,
-                },
-                mobile: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
-                },
+                desktop,
+                mobile,
               }
             }
           };
-        });
 
-      return await newImageObj;
+      return newImageObj;
     },
     async getCollection(i) {
       const component = this;

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -659,35 +659,35 @@ export default {
     },
     async getImage(i) {
       const component = this;
+      let imageObj;
+      let newImageObj;
 
-      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
-      const imageObj = image.data
+      await axios
+        .get(`${component.interface.endpoint}media/${i}`)
+        .then((output) => {
+          imageObj = output.data;
 
-      let imageAspect = 3.0 / 4.0
-      if (image.height > 0 && image.width > 0) {
-        imgAspect = image.height / image.width
-      }
+          // console.log(imageObj);
 
-      const desktopWidth = 1200
-      const mobileWidth = 600
-
-      const desktop = { width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
-      const mobile = { width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
-
-      const newImageObj = {
+          newImageObj = {
             alt_text: imageObj.alt_text,
             caption: {
               rendered: imageObj.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
             },
             media_details: {
               sizes: {
-                desktop,
-                mobile,
+                desktop: {
+                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1800,quality=75,format=webp`,
+                },
+                mobile: {
+                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
+                },
               }
             }
           };
+        });
 
-      return newImageObj;
+      return await newImageObj;
     },
     async getCollection(i) {
       const component = this;

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -664,7 +664,7 @@ export default {
       const imageObj = image.data
       const mediaDetails = image.data.media_details
 
-      let imageAspect = 3.0 / 4.0
+      let imageAspect
       if (mediaDetails.height > 0 && mediaDetails.width > 0) {
         imageAspect = mediaDetails.height / mediaDetails.width
       }

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -672,8 +672,8 @@ export default {
       const desktopWidth = 1200
       const mobileWidth = 600
 
-      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
-      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
+      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1800,quality=75,format=webp` }
+      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
 
       const newImageObj = {
             alt_text: imageObj.alt_text,

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -659,35 +659,36 @@ export default {
     },
     async getImage(i) {
       const component = this;
-      let imageObj;
-      let newImageObj;
 
-      await axios
-        .get(`${component.interface.endpoint}media/${i}`)
-        .then((output) => {
-          imageObj = output.data;
+      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
+      const imageObj = image.data
+      const mediaDetails = image.data.media_details
 
-          // console.log(imageObj);
+      let imageAspect = 3.0 / 4.0
+      if (mediaDetails.height > 0 && mediaDetails.width > 0) {
+        imageAspect = mediaDetails.height / mediaDetails.width
+      }
 
-          newImageObj = {
+      const desktopWidth = 1200
+      const mobileWidth = 600
+
+      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
+      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=600,quality=75,format=webp` }
+
+      const newImageObj = {
             alt_text: imageObj.alt_text,
             caption: {
               rendered: imageObj.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
             },
             media_details: {
               sizes: {
-                desktop: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1800,quality=75,format=webp`,
-                },
-                mobile: {
-                  source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp`,
-                },
+                desktop,
+                mobile,
               }
             }
           };
-        });
 
-      return await newImageObj;
+      return newImageObj;
     },
     async getCollection(i) {
       const component = this;

--- a/components/global/Picture.vue
+++ b/components/global/Picture.vue
@@ -10,6 +10,7 @@
       :alt="alt"
       :loading="loading"
       width="100%"
+      :aspect-ratio="sizes.mobile.aspect_ratio ?? ''"
       @error="handle404"
     />
   </picture>

--- a/components/global/Picture.vue
+++ b/components/global/Picture.vue
@@ -10,7 +10,6 @@
       :alt="alt"
       :loading="loading"
       width="100%"
-      :height="sizes.mobile.height"
       @error="handle404"
     />
   </picture>

--- a/components/global/Picture.vue
+++ b/components/global/Picture.vue
@@ -10,6 +10,7 @@
       :alt="alt"
       :loading="loading"
       width="100%"
+      :height="sizes.mobile.height"
       @error="handle404"
     />
   </picture>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,6 +5,10 @@
 </template>
 
 <style lang="scss">
+.layout {
+  min-height: 60vh;
+}
+
 .page {
   @include breakpoint(large) {
     min-height: 160vh;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,10 +5,6 @@
 </template>
 
 <style lang="scss">
-.layout {
-  min-height: 60vh;
-}
-
 .page {
   @include breakpoint(large) {
     min-height: 160vh;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -85,6 +85,6 @@ export default defineNuxtConfig({
         asyncContext: true,
     },
 
-    devtools: { enabled: true },
+    devtools: { enabled: process.mode === 'development' },
     compatibilityDate: '2025-02-27',
 });


### PR DESCRIPTION
- Changes `getImage` in MediaContext, Article, and ArticleGrid to generate image aspect ratio from media height / width
- Emits `aspect-ratio` in `Picture` component 

@gregoryspragginsjr Feel free to merge this when copacetic for you, it should resolve the CLS issues showing up in lighthouse on pages with many images (except for collections pages). Please preserve these calculations into `PictureLoader` if you end up refactoring that for generalization across picture-loading context.