### PR TITLE
Test for layout shift improvements: use actual widths / heights on image components

### DIFF
--- a/components/global/Picture.vue
+++ b/components/global/Picture.vue
@@ -10,8 +10,8 @@
       :alt="alt"
       :loading="loading"
       :aspect-ratio="sizes.mobile.aspect_ratio ?? ''"
-      width="100%"
-      height="50%"
+      :width="sizes.mobile.width ?? '100%'"
+      :height="sizes.mobile.height ?? '50%'"
       @error="handle404"
     />
   </picture>


### PR DESCRIPTION
This PR is strictly a test and should only be merged if the branch QA's successfully. I removed the percent heights / widths on `Picture` components (used in MediaContext slides, in article grids for posts, etc etc) to see if it improves the cumulative layout shift scores for objects with the swipe animation.