### PR TITLE
adds open new tab functionality to In The News block on exhibits

### DIFF
--- a/components/global/Article.vue
+++ b/components/global/Article.vue
@@ -13,7 +13,8 @@
       :button="{
         type: button_type,
         title: 'Read News',
-        url: post.link
+        url: post.link,
+        target: openNewTab ? '_blank' : '_self',
       }"
     />
     <Context
@@ -156,6 +157,10 @@ export default {
     },
     button: {
       required: false,
+    },
+    openNewTab: {
+        type: Boolean,
+        required: false,
     }
   },
   methods: {

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -393,6 +393,7 @@
           :hover="hover"
           :bordered="bordered"
           :button_type="button_type"
+          :openNewTab="item.openNewTab"
         />
       </div>
       <div
@@ -682,6 +683,7 @@ export default {
         paragraph: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_paragraph`],
         button: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_button`],
         image: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : await component.getImage(component.blockData[`items_${i}_image`]),
+        openNewTab: component.openNewTab(component.blockData, i),
       }))).then((output) => {
         component.newItems = output; 
       })
@@ -709,6 +711,16 @@ export default {
     }
   },
   methods: {
+    openNewTab(blockData, i) {
+        if (
+            blockData[`items_${i}_entry_type`] == 'selection' &&
+            blockData[`items_${i}_open_new_tab`]
+        ) {
+            return blockData[`items_${i}_open_new_tab`] == 1;
+        }
+
+        return false;
+    },
     // Loads from _count API
     async getObjectCount(query, endpoint, username, password, perPage) {
       // Create a mutable clone and remove keys not legal in count reqs


### PR DESCRIPTION
Adds new 'open in new tab' functionality to Article Grid where manually selected items are used. There has been a new ACF field already added to prod. The original test page was https://museum.colby.edu/exhibitions/painted-our-bodies-hearts-and-village, the In the News sections. Jillian wanted those buttons to open in new tabs.

Open in new tab functionality is already in place where the ACF "links" are used, but was not in place for when you're selecting from a drop down of things, like posts. I believe this will only work for the this specific AG config, we may need to add it other places if Jillian wants to.