### PR TITLE
Coalesce media REST queries for ArticleGrid, MediaContext

### DIFF
--- a/components/Context.vue
+++ b/components/Context.vue
@@ -66,12 +66,14 @@
         <Picture
           :alt="image.alt_text"
           :sizes="image.media_details.sizes"
+          :loading="layoutPosition > 0 ? 'lazy' : 'eager'"
         />
       </NuxtLink>
       <Picture
         v-else
         :alt="image.alt_text"
         :sizes="image.media_details.sizes"
+        :loading="layoutPosition > 0 ? 'lazy' : 'eager'"
       />
     </div>
     <p
@@ -149,6 +151,10 @@ export default {
     },
     button: {
       required: false,
+    },
+    layoutPosition: {
+      type: Number,
+      default: 0
     }
   },
   watch: {

--- a/components/global/Article.vue
+++ b/components/global/Article.vue
@@ -10,6 +10,7 @@
       :heading="post.title.rendered"
       :subheading="formatDate(post.date)"
       :image="stagedImage"
+      :layoutPosition="layoutPosition"
       :button="{
         type: button_type,
         title: 'Read News',
@@ -25,6 +26,7 @@
       :subheading="formatDate(post.acf.date, 'events') + (post.acf.end_date && post.acf.end_date != '' && post.acf.date != post.acf.end_date ? `&ndash;${formatDate(post.acf.end_date, 'events')}` : '' )"
       :subheading2="post.type == 'events' ? `${formatTime(post.acf.start_time)}&ndash;${formatTime(post.acf.end_time)}` : undefined"
       :image="stagedImage"
+      :layoutPosition="layoutPosition"
       :button="{
         type: button_type,
         title: post.type == 'events' ? 'Event Details' : 'Exhibition Details',
@@ -37,6 +39,7 @@
       :bordered="bordered"
       :heading="post.title.rendered"
       :image="stagedImage"
+      :layoutPosition="layoutPosition"
       :button="{
         srOnly: true,
         type: button_type,
@@ -51,6 +54,7 @@
       :heading="post.title.rendered"
       :subheading="formatDate(post.date)"
       :image="stagedImage"
+      :layoutPosition="layoutPosition"
       :button="{
         type: button_type,
         title: 'Read News',
@@ -65,6 +69,7 @@
       :subheading="paragraph_entry_type == 'description' && image ? image.object_title : subheading"
       :subheading2="paragraph_entry_type == 'description' && image ? image.object_creation_date : subheading2"
       :image="image"
+      :layoutPosition="layoutPosition"
       :caption="paragraph_entry_type == 'description' && image ? image.caption.rendered : undefined"
       :paragraph="paragraph"
       :button="stagedButton"
@@ -159,8 +164,12 @@ export default {
       required: false,
     },
     openNewTab: {
-        type: Boolean,
-        required: false,
+      type: Boolean,
+      required: false,
+    },
+    layoutPosition: {
+      type: Number,
+      default: 0
     }
   },
   methods: {

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -598,35 +598,6 @@ export default {
       required: false,
     }
   },
-  mapImageData(restData) {
-    // Maps data from the REST API to our internal representation
-    const mediaDetails = restData.media_details
-
-    let imageAspect
-    if (mediaDetails.height > 0 && mediaDetails.width > 0) {
-      imageAspect = mediaDetails.height / mediaDetails.width
-    }
-
-    const desktopWidth = 1200
-    const mobileWidth = 600
-
-    const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1800) }
-    const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1200) }
-
-    return {
-          id: restData.id,
-          alt_text: restData.alt_text,
-          caption: {
-            rendered: restData.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
-          },
-          media_details: {
-            sizes: {
-              desktop,
-              mobile,
-            }
-          }
-        }
-  },
   async created() {
     this.interface = useInterfaceStore();
     const component = this;
@@ -727,6 +698,7 @@ export default {
             heading: undefined,
             subheading: undefined,
             paragraph: undefined,
+            paragraph_entry_type: undefined,
             button: undefined,
             image: undefined,
           }
@@ -736,6 +708,7 @@ export default {
             heading: component.blockData[`items_${i}_heading`],
             subheading:  component.blockData[`items_${i}_subheading`],
             paragraph:  component.blockData[`items_${i}_paragraph`],
+            paragraph_entry_type: component.blockData[`items_${i}_paragraph_entry_type`],
             button: component.blockData[`items_${i}_button`],
             image: imagesData.find( img => img.id === component.blockData[`items_${i}_image`] )
           }
@@ -1171,6 +1144,39 @@ export default {
         });
 
       return await postObj;
+    },
+    imageUrlWidth(guid,width) {
+      // Formats the GUID for use with imagedelivery, with a width
+      return `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${guid.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=${width},quality=75,format=webp`
+    },
+    mapImageData(restData) {
+      // Maps data from the REST API to our internal representation
+      const mediaDetails = restData.media_details
+
+      let imageAspect
+      if (mediaDetails.height > 0 && mediaDetails.width > 0) {
+        imageAspect = mediaDetails.height / mediaDetails.width
+      }
+
+      const desktopWidth = 1200
+      const mobileWidth = 600
+
+      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1800) }
+      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1200) }
+
+      return {
+            id: restData.id,
+            alt_text: restData.alt_text,
+            caption: {
+              rendered: restData.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
+            },
+            media_details: {
+              sizes: {
+                desktop,
+                mobile,
+              }
+            }
+          }
     },
     async getImages(imageIds) {
       const endpointUrl = new URL('media',this.interface.endpoint)

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -685,14 +685,19 @@ export default {
       let postSelections = []
       let imageIds = []
 
-      for (let itemNum=0; itemNum< this.items; itemNum++) {
-        if (component.blockData[`items_${itemNum}_entry_type`] === 'selection') {
+      for (let itemNum=0; itemNum < this.items; itemNum++) {
+        const entryType = component.blockData[`items_${itemNum}_entry_type`]
+
+        if (entryType === 'selection') {
           // Done as arrays for spread args in the consumer downfile -- rewrite this later!
           postSelections.push([ 
               component.blockData[`items_${itemNum}_${component.blockData[`items_${itemNum}_selection_type`]}_selection`], 
               component.blockData[`items_${itemNum}_selection_type`] 
                   ])
-        } else {
+          continue
+        } 
+
+        if (component.blockData[`items_${itemNum}_image`] || component.blockData[`items_${itemNum}_image`] === 0) {
           imageIds.push(component.blockData[`items_${itemNum}_image`])
         }
       }
@@ -707,17 +712,20 @@ export default {
             post: postsSelectionData.find( p => p.id === `items_${i}_${component.blockData[`items_${i}_selection_type`]}_selection`),
             heading: undefined,
             subheading: undefined,
+            subheading2: undefined,
             paragraph: undefined,
             paragraph_entry_type: undefined,
             button: undefined,
             image: undefined,
             openNewTab: component.openNewTab(component.blockData, i)
           }
+
         default:
           return {
             post: undefined,
             heading: component.blockData[`items_${i}_heading`],
             subheading:  component.blockData[`items_${i}_subheading`],
+            subheading2:  component.blockData[`items_${i}_subheading2`],
             paragraph:  component.blockData[`items_${i}_paragraph`],
             paragraph_entry_type: component.blockData[`items_${i}_paragraph_entry_type`],
             button: component.blockData[`items_${i}_button`],
@@ -1189,6 +1197,9 @@ export default {
       return {
             id: restData.id,
             alt_text: restData.alt_text,
+            artist_name: restData.acf?.artist_name,
+            object_title: restData.acf?.object_title,
+            object_creation_date: restData.acf?.object_creation_date,
             caption: {
               rendered: restData.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
             },

--- a/components/global/ArticleGrid.vue
+++ b/components/global/ArticleGrid.vue
@@ -356,6 +356,7 @@
           :hover="hover"
           :bordered="bordered"
           :button_type="button_type"
+          :layoutPosition="layoutPosition"
         />
       </div>
       <div
@@ -368,6 +369,7 @@
           :hover="hover"
           :bordered="bordered"
           :button_type="button_type"
+          :layoutPosition="layoutPosition"
         />
       </div>
       <div
@@ -380,6 +382,7 @@
           :hover="hover"
           :bordered="bordered"
           :button_type="button_type"
+          :layoutPosition="layoutPosition"
         />
       </div>
       <div
@@ -394,6 +397,7 @@
           :bordered="bordered"
           :button_type="button_type"
           :openNewTab="item.openNewTab"
+          :layoutPosition="layoutPosition"
         />
       </div>
       <div
@@ -406,6 +410,7 @@
           :hover="hover"
           :bordered="bordered"
           :button_type="button_type"
+          :layoutPosition="layoutPosition"
         />
       </div>
     </div>
@@ -597,6 +602,10 @@ export default {
     blockData: {
       type: Object,
       required: false,
+    },
+    layoutPosition: {
+      type: Number,
+      default: 0
     }
   },
   async created() {

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -460,17 +460,48 @@ export default {
       });
     } else if (typeof this.items === 'number') {
 
-      await Promise.all([...Array(this.items)].map(async (el, i) => ({
-        post: component.blockData[`items_${i}_entry_type`] == 'selection' ? await component.getPost(component.blockData[`items_${i}_${component.blockData[`items_${i}_selection_type`]}_selection`], component.blockData[`items_${i}_selection_type`]) : undefined,
-        heading: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_heading`],
-        subheading: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_subheading`],
-        paragraph: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_paragraph`],
-        button: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : component.blockData[`items_${i}_button`],
-        image: component.blockData[`items_${i}_entry_type`] == 'selection' ? undefined : await component.getImage(component.blockData[`items_${i}_image`]),
-      }))).then((output) => {
-        component.newItems = output;
-        // component.renderGlide();
+      let postSelections = []
+      let imageIds = []
+
+      for (let itemNum=0; itemNum< this.items; itemNum++) {
+        if (component.blockData[`items_${itemNum}_entry_type`] === 'selection') {
+          // Done as arrays for spread args in the consumer downfile -- rewrite this later!
+          postSelections.push([ 
+              component.blockData[`items_${itemNum}_${component.blockData[`items_${itemNum}_selection_type`]}_selection`], 
+              component.blockData[`items_${itemNum}_selection_type`] 
+                  ])
+        } else {
+          imageIds.push(component.blockData[`items_${itemNum}_image`])
+        }
+      }
+
+      const imagesData = await this.getImages(imageIds)
+      const postsSelectionData = await Promise.all(postSelections.map( async (ps) => await this.getPost(...ps) ))
+
+      const mappedItems = [...Array(this.items)].map( (item,i) => {
+        switch (component.blockData[`items_${i}_entry_type`]) {
+        case 'selection':
+          return {
+            post: postsSelectionData.find( p => p.id === `items_${i}_${component.blockData[`items_${i}_selection_type`]}_selection`),
+            heading: undefined,
+            subheading: undefined,
+            paragraph: undefined,
+            button: undefined,
+            image: undefined,
+          }
+        default:
+          return {
+            post: undefined,
+            heading: component.blockData[`items_${i}_heading`],
+            subheading:  component.blockData[`items_${i}_subheading`],
+            paragraph:  component.blockData[`items_${i}_paragraph`],
+            button: component.blockData[`items_${i}_button`],
+            image: imagesData.find( img => img.id === component.blockData[`items_${i}_image`] )
+          }
+        }
       })
+
+      this.newItems = [...mappedItems]
     } else if (this.items_type == 'objects') {
       component.renderGlide();
     }
@@ -665,12 +696,13 @@ export default {
 
       return await postObj;
     },
-    async getImage(i) {
-      const component = this;
-
-      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
-      const imageObj = image.data
-      const mediaDetails = image.data.media_details
+    imageUrlWidth(guid,width) {
+      // Formats the GUID for use with imagedelivery, with a width
+      return `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${guid.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=${width},quality=75,format=webp`
+    },
+    mapImageData(restData) {
+      // Maps data from the REST API to our internal representation
+      const mediaDetails = restData.media_details
 
       let imageAspect
       if (mediaDetails.height > 0 && mediaDetails.width > 0) {
@@ -680,13 +712,14 @@ export default {
       const desktopWidth = 1200
       const mobileWidth = 600
 
-      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1800,quality=75,format=webp` }
-      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: `https://imagedelivery.net/O3WFf73JpL0l5z5Q_yyhTw/${imageObj.guid.rendered.replace('https://', '').replace('http://', '').replace('wp-content/uploads/', '').replace('wp-json/wp/v2/', '')}/w=1200,quality=75,format=webp` }
+      const desktop = { aspect_ratio: imageAspect, width: desktopWidth, height: desktopWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1800) }
+      const mobile = { aspect_ratio: imageAspect, width: mobileWidth, height: mobileWidth * imageAspect, source_url: this.imageUrlWidth(restData.guid.rendered, 1200) }
 
-      const newImageObj = {
-            alt_text: imageObj.alt_text,
+      return {
+            id: restData.id,
+            alt_text: restData.alt_text,
             caption: {
-              rendered: imageObj.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
+              rendered: restData.description.rendered.replace(/<img[^>]*>/g,"").replace(/<p[^>]*>|<\/p>/g, '').replace(/\r?\n|\r/g, "").replace(/<a[^>]*>|<\/a>/g, ''),
             },
             media_details: {
               sizes: {
@@ -694,9 +727,26 @@ export default {
                 mobile,
               }
             }
-          };
+          }
+    },
+    async getImages(imageIds) {
+      const endpointUrl = new URL('media',this.interface.endpoint)
+      endpointUrl.searchParams.set('include', imageIds)
 
-      return newImageObj;
+      const request = await axios.get(endpointUrl.href)
+      const data = request.data
+
+      const mapped = data.map( d => this.mapImageData(d) )
+
+      return mapped
+    },
+    async getImage(i) {
+      const component = this;
+
+      const image = await axios.get(`${component.interface.endpoint}media/${i}`)
+      const imageObj = image.data
+
+      return this.mapImageData(imageObj)
     },
     async getCollection(i) {
       const component = this;

--- a/components/global/MediaContext.vue
+++ b/components/global/MediaContext.vue
@@ -54,7 +54,7 @@
                       :classes="'object-cover'"
                       :alt="item.image.alt_text"
                       :sizes="item.image.media_details.sizes"
-                      :loading="'eager'"
+                      :loading="(layoutPosition > 0 || index > 0) ? 'lazy' : 'eager'"
                     />
                   </button>
                   <div
@@ -69,14 +69,14 @@
                         :classes="'object-cover'"
                         :alt="item.image.alt_text"
                         :sizes="item.image.media_details.sizes"
-                        :loading="'eager'"
+                        :loading="(layoutPosition > 0 || index > 0) ? 'lazy' : 'eager'"
                       />
                     </NuxtLink>
                     <VueImageZoomer
                       v-else-if="artificialDelayFinished"
                       :regular="item.image.media_details.sizes.full.source_url"
                       :click-zoom="true"
-                      :lazyload="index == 0 ? false : true"
+                      :lazyload="(layoutPosition > 0 || index == 0) ? false : true"
                     />
                     <div
                       v-if="item.image.caption && variant == 'full-width'"
@@ -152,7 +152,7 @@
                       <PictureLoader
                         :classes="'object-cover'"
                         :post="item.post"
-                        :loading="index > 0 ? 'lazy' : 'eager'"
+                        :loading="(layoutPosition > 0 || index > 0) ? 'lazy' : 'eager'"
                       />
                     </NuxtLink>
                     <div
@@ -173,16 +173,18 @@
                         :classes="'object-cover'"
                         :alt="item.image.alt_text"
                         :sizes="item.image.media_details.sizes"
-                        :loading="index > 0 ? 'lazy' : 'eager'"
+                        :loading="(layoutPosition > 0 || index > 0 ) ? 'lazy' : 'eager'"
                       />
                     </NuxtLink>
+                    <!-- insert a lil comment -->
                     <Picture
                       v-else
-                      :classes="'object-cover'"
+                      :classes="`object-cover ${layoutPosition} ${index}`"
                       :alt="item.image.alt_text"
                       :sizes="item.image.media_details.sizes"
-                      :loading="index > 0 ? 'lazy' : 'eager'"
+                      :loading="(layoutPosition > 0 || index > 0 ) ? 'lazy' : 'eager'"
                     />
+                    <!-- another il comment -->
                     <div
                       v-if="item.image.caption.rendered && variant == 'full-width'"
                       class="media-context__caption"
@@ -430,6 +432,10 @@ export default {
     blockData: {
       type: Object,
       required: false,
+    },
+    layoutPosition: {
+      type: Number,
+      default: 0
     }
   },
   watch: {

--- a/components/global/PictureLoader.vue
+++ b/components/global/PictureLoader.vue
@@ -1,6 +1,5 @@
 <template>
   <Picture
-    v-if="image"
     :classes="classes"
     :alt="image.alt_text"
     :sizes="image.media_details.sizes"

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -93,13 +93,14 @@ export default {
 
         page.getBreadcrumbs(post);
 
-        page.components = post.block_data.map((component) => {
+        page.components = post.block_data.map((component, i) => {
           
           component.type = component.blockName
             .replace('acf/','')
             .replace(/\//g,'-');
 
           return {
+            layoutPosition: i,
             type: component.type,
             ...component.attrs.data,
             attrs: component.attrs.data ? undefined : component.attrs,


### PR DESCRIPTION
This PR coalesces media requests in `ArticleGrid` and `MediaContext` by pulling all image IDs from block content and making a single request to the `/media` endpoint with an `include` parameter for all the component's media. 

Should be good to merge but needs a full QA against the various post types / content verticals given that the components are often shared-with-options.

ETA: This PR also adds a `layoutPosition` property to MediaContext, ArticleGrid, and Article elements to help correctness in driving `@loading` attributes on img tags.